### PR TITLE
Unit testing framework for caffe2_ref_test

### DIFF
--- a/onnx_caffe2/backend.py
+++ b/onnx_caffe2/backend.py
@@ -130,6 +130,7 @@ class Caffe2Backend(Backend):
         'Conv3D': 'Conv',
         'MaxPool2D': 'MaxPool',
         'AveragePool2D': 'AveragePool',
+        'Dot': 'MatMul',
     }
 
     # NB: domain is RENAMED operator names, not the originals

--- a/tests/caffe2_ref_test.py
+++ b/tests/caffe2_ref_test.py
@@ -27,6 +27,106 @@ import unittest
 from caffe2.python.models.download import downloadFromURLToFile, getURLFromName, deleteDirectory
 
 
+class NodeSpec(object):
+    """
+    Describes a onnx.NodeProto, but without inputs/outputs
+    (which will be inferred).
+    """
+    def __init__(self, name, **kwargs):
+        self.name = name
+        self.kwargs = kwargs
+
+
+N = NodeSpec
+
+
+def create_input(call_args):
+    """
+    Creates a tuple of Numpy ndarray from a template 'call_args'; every embedded
+    tuple in call_args is converted into a random ndarray with the specified
+    dimensions.
+    """
+    if not isinstance(call_args, tuple):
+        call_args = (call_args,)
+
+    def map_arg(arg):
+        if isinstance(arg, tuple):
+            return np.random.randn(*arg).astype(np.float32)
+        else:
+            return arg
+
+    return tuple(map_arg(arg) for arg in call_args)
+
+
+class Caffe2NumpySpec(object):
+    """
+    A test for a single ONNX node against a Numpy reference implementation.
+    """
+    def __init__(self, name, node, np_impl, inputs):
+        """
+        Arguments:
+            name (string): Eventual name of the test.  Must be prefixed
+                with 'test_'.
+            node (NodeSpec): The ONNX node's name and attributes to be tested;
+                inputs and outputs will be inferred from other arguments of this
+                spec.
+            np_impl (lambda): A function from any number of Numpy ndarrays,
+                to a single ndarray or tuple of ndarrays.
+            inputs (tuple of ndarrays or size tuples): A specification of
+                the input to the operator.
+        """
+        # We don't prepend the 'test_' prefix to improve greppability
+        if not name.startswith("test_"):
+            raise ValueError("Test name must start with test_")
+        self.name = name
+        self.node = node
+        self.np_impl = np_impl
+        self.inputs = inputs
+
+    def run(self, test_self):
+        # TODO: In some cases we should generate multiple random inputs
+        # and test (ala Hypothesis)
+        args = create_input(self.inputs)
+        np_results = self.np_impl(*args)
+        if not isinstance(np_results, tuple):
+            np_results = (np_results, )
+        input_names = ["input_{}".format(i) for i in range(len(args))]
+        output_names = ["output_{}".format(i) for i in range(len(np_results))]
+        node_def = helper.make_node(self.node.name, input_names, output_names, **self.node.kwargs)
+        caffe2_results = c2.run_node(node_def, args)
+        test_self.assertEqual(len(np_results), len(caffe2_results))
+        for i in range(len(output_names)):
+            np.testing.assert_almost_equal(np_results[i], caffe2_results[i])
+
+CN = Caffe2NumpySpec
+
+
+L = 20
+M = 10
+S = 5
+const2_np = np.random.randn(S, S)
+const2_onnx = onnx.helper.make_tensor("const2", onnx.TensorProto.FLOAT, (S, S), const2_np.flatten().astype(float))
+
+# TODO: These Numpy specs will be generally useful to backend implementations,
+# so they should get moved out of here at some point
+#
+# NB: There is some degree of duplication between this and
+# 'caffe2/caffe2/python/operator_test', but these are against ONNX nodes,
+# not Caffe2 nodes.
+#
+# TODO: Some of these tests will be done most conveniently by running a Caffe2
+# operator directly (i.e., something like a before-after translation). If you
+# need this, extend the test runner to handle these conveniently
+node_tests = [
+  CN("test_abs", N("Abs"), np.abs, inputs=((S, S, S),)),
+  CN("test_add", N("Add"), np.add, inputs=((S, S, S), (S, S, S))),
+  CN("test_add_bcast", N("Add", broadcast=1), np.add, inputs=((S, M), (S))),
+  CN("test_constant", N("Constant", value=const2_onnx), lambda: const2_np, inputs=()),
+  CN("test_relu", N("Relu"), lambda x: np.clip(x, 0, np.inf), inputs=((S, S, S),)),
+  # TODO: Add all the other operators
+  ]
+
+
 class TestCaffe2Reference(unittest.TestCase):
     def setUp(self):
         np.random.seed(seed=0)
@@ -201,6 +301,18 @@ class TestCaffe2Reference(unittest.TestCase):
         model = 'densenet121'
         self._download(model)
         self._test_net(model)
+
+
+class TestCaffe2ReferenceNode(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(seed=0)
+
+
+for test in node_tests:
+    assert not hasattr(TestCaffe2Reference, test.name), 'Two tests have the same name: ' + test.name
+    # Due to Python method binding shenanigans, eta expansion does
+    # not hold: (lambda x: m.f(x)) != m.f
+    setattr(TestCaffe2ReferenceNode, test.name, lambda self: test.run(self))
 
 
 if __name__ == '__main__':

--- a/tests/caffe2_ref_test.py
+++ b/tests/caffe2_ref_test.py
@@ -116,12 +116,16 @@ const2_onnx = onnx.helper.make_tensor("const2", onnx.TensorProto.FLOAT, (S, S), 
 #
 # TODO: Some of these tests will be done most conveniently by running a Caffe2
 # operator directly (i.e., something like a before-after translation). If you
-# need this, extend the test runner to handle these conveniently
+# need this, extend the test runner to handle these conveniently; possibly
+# use Caffe2's immediate mode
 node_tests = [
   CN("test_abs", N("Abs"), np.abs, inputs=((S, S, S),)),
   CN("test_add", N("Add"), np.add, inputs=((S, S, S), (S, S, S))),
   CN("test_add_bcast", N("Add", broadcast=1), np.add, inputs=((S, M), (S))),
   CN("test_constant", N("Constant", value=const2_onnx), lambda: const2_np, inputs=()),
+  # TODO: Are we actually supporting other dot modes?  In that case, some fancy
+  # footwork is necessary...
+  CN("test_dot", N("Dot"), np.dot, inputs=((S, M), (M, L))),
   CN("test_relu", N("Relu"), lambda x: np.clip(x, 0, np.inf), inputs=((S, S, S),)),
   # TODO: Add all the other operators
   ]


### PR DESCRIPTION
This adds the necessary infrastructure for performing per-node
unit tests for various operators.

I will add more tests in a later commit.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>