### PR TITLE
Add support for converting caffe2 init_net to initializers

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -52,4 +52,4 @@ pip install pytest-cov psutil
 
 # run caffe2 tests
 cd "$workdir"
-pytest "$onnx_c2_dir/tests/caffe2_ref_test.py"
+pytest -s "$onnx_c2_dir/tests/caffe2_ref_test.py"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -48,7 +48,7 @@ fi
 onnx_dir="$workdir/onnx"
 git clone "https://github.com/onnx/onnx.git" "$onnx_dir" --recursive
 pip install "$onnx_dir"
-pip install pytest-cov
+pip install pytest-cov psutil
 
 # run caffe2 tests
 cd "$workdir"

--- a/onnx_caffe2/frontend.py
+++ b/onnx_caffe2/frontend.py
@@ -5,12 +5,13 @@ To run this, you will need to have Caffe2 installed as well.
 
 import caffe2
 from caffe2.python import core, workspace
-from onnx import onnx_pb2, checker
+from onnx import onnx_pb2, checker, helper, numpy_helper
 from caffe2.proto import caffe2_pb2
 import onnx.defs
 from enum import Enum
 import contextlib
 import re
+import numpy as np
 
 # Special translators for operators that are different between Caffe2 and
 # ONNX. In most cases, this should be empty - as the effort of ONNX is
@@ -236,6 +237,33 @@ class NameMap(object):
             self.unique += 1
         # allowed to override!
         return self._add(name, mk())
+
+
+def caffe2_init_net_to_initializers(init_net):
+    initializers = []
+    for init_op in init_net.op:
+        assert not init_op.input
+        data_type_map = {
+            'GivenTensorFill': (onnx_pb2.TensorProto.FLOAT, 'floats', np.float32),
+            'GivenTensorInt64Fill': (onnx_pb2.TensorProto.INT64, 'ints', np.int64),
+            'GivenTensorIntFill': (onnx_pb2.TensorProto.INT32, 'ints', np.int32),
+            'GivenTensorBoolFill': (onnx_pb2.TensorProto.BOOL, 'ints', np.int32),
+        }
+        try:
+            data_type, field_name, np_type = data_type_map[init_op.type]
+        except KeyError:
+            raise RuntimeError(
+                "Can not translate init_net with operator '{}' to initializers".format(init_op.type)
+            )
+        args = {a.name: a for a in init_op.arg}
+        initializers.append(helper.make_tensor(
+            name=init_op.output[0],
+            data_type=data_type,
+            dims=args['shape'].ints,
+            vals=np.asarray(getattr(args['values'], field_name), dtype=np_type).tobytes(),
+            raw=True,
+        ))
+    return initializers
 
 
 def caffe2_net_to_onnx_graph(net_def):

--- a/onnx_caffe2/frontend.py
+++ b/onnx_caffe2/frontend.py
@@ -249,6 +249,7 @@ def caffe2_init_net_to_initializers(init_net):
                 'GivenTensorInt64Fill': (onnx_pb2.TensorProto.INT64, 'ints', np.int64, True),
                 'GivenTensorIntFill': (onnx_pb2.TensorProto.INT32, 'ints', np.int32, True),
                 'GivenTensorBoolFill': (onnx_pb2.TensorProto.BOOL, 'ints', np.int32, True),
+                # raw_data can not be used to store strings
                 'GivenTensorStringFill': (onnx_pb2.TensorProto.STRING, 'strings', None, False),
             }[init_op.type]
         except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     description="Caffe2 frontend and backend of Open Neural Network Exchange",
     install_requires=install_requires,
     setup_requires=['pytest-runner'],
-    tests_require=['numpy', 'pytest-cov'],
+    tests_require=['numpy', 'pytest-cov', 'psutil'],
     cmdclass=cmdclass,
     packages=find_packages(),
     author='bddppq',

--- a/tests/caffe2_ref_test.py
+++ b/tests/caffe2_ref_test.py
@@ -238,7 +238,7 @@ class TestCaffe2Reference(unittest.TestCase):
         data = np.random.randn(n, c, h, w).astype(np.float32)
         inputs = [data]
         c2_ref = c2_onnx.caffe2_net_reference(c2_init_net, c2_predict_net, inputs)
-        print(net_name, '(random inputs generated):' psutil.virtual_memory())
+        print(net_name, '(random inputs generated):', psutil.virtual_memory())
 
         predict_graph = c2_onnx.caffe2_net_to_onnx_graph(c2_predict_net)
         # # Test using separated init_graph

--- a/tests/caffe2_ref_test.py
+++ b/tests/caffe2_ref_test.py
@@ -21,6 +21,7 @@ from onnx import onnx_pb2
 import onnx_caffe2.frontend as c2_onnx
 import onnx_caffe2.backend as c2
 
+import psutil
 import numpy as np
 import google.protobuf.text_format
 import unittest
@@ -236,6 +237,7 @@ class TestCaffe2Reference(unittest.TestCase):
         inputs = [data]
         c2_ref = c2_onnx.caffe2_net_reference(c2_init_net, c2_predict_net, inputs)
 
+        print(net_name, psutil.virtual_memory())
         predict_graph = c2_onnx.caffe2_net_to_onnx_graph(c2_predict_net)
         # Test using separated init_graph
         init_graph = c2_onnx.caffe2_net_to_onnx_graph(c2_init_net)
@@ -245,6 +247,7 @@ class TestCaffe2Reference(unittest.TestCase):
             np.testing.assert_almost_equal(
                 onnx_output[blob_name], c2_ref[blob_name], decimal=decimal)
 
+        print(net_name, psutil.virtual_memory())
         # Test using initializers
         initializers = c2_onnx.caffe2_init_net_to_initializers(c2_init_net)
         predict_graph.initializer.extend(initializers)
@@ -253,6 +256,7 @@ class TestCaffe2Reference(unittest.TestCase):
         for blob_name in c2_ref.keys():
             np.testing.assert_almost_equal(
                 onnx_output[blob_name], c2_ref[blob_name], decimal=decimal)
+        print(net_name, psutil.virtual_memory())
 
     def _download(self, model):
         model_dir = self.model_dir(model)

--- a/tests/caffe2_ref_test.py
+++ b/tests/caffe2_ref_test.py
@@ -217,6 +217,7 @@ class TestCaffe2Reference(unittest.TestCase):
         return os.path.join(models_dir, model)
 
     def _test_net(self, net_name, input_blob_dims=[1, 3, 224, 224], decimal=7):
+        print(net_name, psutil.virtual_memory())
         model_dir = self.model_dir(net_name)
         # predict net is stored as a protobuf text
         c2_predict_pb = os.path.join(model_dir, 'predict_net.pbtxt')


### PR DESCRIPTION
When we export onnx model, we would like to combine both init net and predict net into one onnx graph.