### PR TITLE
Fix the bug that dummy_name can collide with existing names in the graph

### DIFF
--- a/onnx_caffe2/backend.py
+++ b/onnx_caffe2/backend.py
@@ -584,6 +584,19 @@ class Caffe2Backend(Backend):
             for output in graph_or_nodes.output:
                 output.name = renamed.get(output.name, output.name)
 
+    @staticmethod
+    def _all_names_in_graph(graph):
+        if graph is None:
+            return set()
+
+        names = set()
+        names.update(value_info.name for value_info in graph.input)
+        names.update(value_info.name for value_info in graph.output)
+        for node in graph.node:
+            names.update(node.input)
+            names.update(node.output)
+        return names
+
     @classmethod
     def onnx_graph_to_caffe2_net(cls, graph_def):
         cls._inplace_rewrite(graph_def)
@@ -594,6 +607,8 @@ class Caffe2Backend(Backend):
         else:
             init_net = caffe2_pb2.NetDef()
             initialized = set()
+
+        dummy_name(cls._all_names_in_graph(graph_def) | initialized)
 
         predict_net = caffe2_pb2.NetDef()
         predict_net.name = graph_def.name

--- a/onnx_caffe2/helper.py
+++ b/onnx_caffe2/helper.py
@@ -11,10 +11,26 @@ from onnx.backend.base import namedtupledict
 from onnx_caffe2.workspace import Workspace
 
 
-def dummy_name(seed=[0]):
-    res = 'OC2_DUMMY_{}'.format(seed[0])
-    seed[0] += 1
-    return res
+class _DummyNameFactory(object):
+    used_names = set()
+    counter = 0
+
+    @classmethod
+    def dummy_name(cls, used_names=None):
+        if used_names is not None:
+            cls.used_names.clear()
+            cls.used_names.update(used_names)
+            cls.counter = 0
+            return None
+        else:
+            while True:
+                name = 'OC2_DUMMY_{}'.format(cls.counter)
+                cls.counter += 1
+                if name not in cls.used_names:
+                    cls.used_names.add(name)
+                    return name
+
+dummy_name = _DummyNameFactory.dummy_name
 
 
 def make_model(graph, **kwargs):

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+from onnx_caffe2.helper import dummy_name
+
+from test_utils import TestCase
+
+
+class TestCaffe2Basic(TestCase):
+    def test_dummy_name(self):
+        names_1 = [dummy_name() for _ in range(3)]
+        dummy_name([])
+        names_2 = [dummy_name() for _ in range(3)]
+        self.assertEqual(names_1, names_2)
+
+        dummy_name(names_1)
+        names_3 = [dummy_name() for _ in range(3)]
+        self.assertFalse(set(names_1) & set(names_3))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
we saw such collision when frontend converted a caffe2 model to onnx model and then later (in a separated invocation) run with backend