### PR TITLE
Init- and predict-splitting optimization

### DIFF
--- a/onnx_caffe2/backend.py
+++ b/onnx_caffe2/backend.py
@@ -588,7 +588,7 @@ class Caffe2Backend(Backend):
         init_net, predict_net = cls._onnx_model_to_caffe2_net(model, device, opset_version, False)
 
         uninitialized = list(set(x for x in init_net.external_input if x not in initialized) |
-                             set(x for x in predict_net.external_input if x not in init_net.external_output))
+                             set(x for x in predict_net.external_input if (x not in init_net.external_output) and (x not in initialized)))
 
         retval = Caffe2Rep(init_net, predict_net, ws, uninitialized)
         return retval
@@ -720,7 +720,7 @@ class Caffe2Backend(Backend):
         predict_net.name = onnx_model.graph.name + '_predict'
 
         if include_initializers:
-            init_net.op.extend(cls._create_tensor_filling_op(tp) for tp in init_model.graph.initializer)
+            init_net.op.extend(cls._create_tensor_filling_op(tp) for tp in onnx_model.graph.initializer)
 
         dummy_name(cls._all_names_in_graph(init_model.graph) | cls._all_names_in_graph(predict_model.graph))
 

--- a/onnx_caffe2/frontend.py
+++ b/onnx_caffe2/frontend.py
@@ -493,7 +493,8 @@ class Caffe2Frontend(object):
                 assert re.match('GivenTensor.*Fill', op.type)
                 assert len(op.output) == 1
                 op.output[0] = ssa_name(op.output[0], 0)
-            assert len(init_net.external_input) == 0
+            init_net.external_input[:] = [ssa_name(name, 0)
+                                          for name in init_net.external_input]
             init_net.external_output[:] = [ssa_name(name, 0)
                                            for name in init_net.external_output]
         if value_info:

--- a/optimize-onnx/src/CMakeLists.txt
+++ b/optimize-onnx/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(optimize-onnx
             assertions.cpp
             export.cpp
             import.cpp
+            optimize.cpp
             interned_strings.cpp
             onnx.pb.cc
 )

--- a/optimize-onnx/src/main.cpp
+++ b/optimize-onnx/src/main.cpp
@@ -42,58 +42,65 @@ int main(int argc, char** argv) {
 
   onnx::ModelProto mp_in;
   ParseProtoFromBytes(&mp_in, buffer.str().c_str(), buffer.str().size());
-  std::shared_ptr<onnx::optimization::Graph> g = onnx::optimization::ImportModel(mp_in);
 
-  if (g.get() != nullptr) {
-    g = onnx::optimization::optimize(g, init, predict);
+  onnx::ModelProto mp_out;
+
+  if (mp_in.has_producer_name()) {
+    mp_out.set_ir_version(mp_in.ir_version());
   }
+  if (mp_in.has_producer_name()) {
+    mp_out.set_producer_name(mp_in.producer_name());
+  }
+  if (mp_in.has_producer_version()) {
+    mp_out.set_producer_version(mp_in.producer_version());
+  }
+  if (mp_in.has_domain()) {
+    mp_out.set_domain(mp_in.domain());
+  }
+  if (mp_in.has_model_version()) {
+    mp_out.set_model_version(mp_in.model_version());
+  }
+  if (mp_in.has_doc_string()) {
+    mp_out.set_doc_string(mp_in.doc_string());
+  }
+  for (int i = 0; i < mp_in.opset_import_size(); i++) {
+    auto& oi_in = mp_in.opset_import(i);
+    auto* oi_out = mp_out.add_opset_import();
+    if (oi_in.has_domain()) {
+      oi_out->set_domain(oi_in.domain());
+    }
+    if (oi_in.has_version()) {
+      oi_out->set_version(oi_in.version());
+    }
+  }
+  for (int i = 0; i < mp_in.metadata_props_size(); i++) {
+    auto& pp_in = mp_in.metadata_props(i);
+    auto* pp_out = mp_out.add_metadata_props();
+    if (pp_in.has_key()) {
+      pp_out->set_key(pp_in.key());
+    }
+    if (pp_in.has_value()) {
+      pp_out->set_value(pp_in.value());
+    }
+  }
+
+  std::shared_ptr<onnx::optimization::Graph> g = onnx::optimization::ImportModel(mp_in);
 
   if (g.get() == nullptr) {
     std::cerr << "Warning: optimize-onnx is unable to parse input model" << std::endl;
-    std::cout << buffer.str();
+
+    // If we can't parse the file, give an empty init graph and copy
+    // the input graph into the predict graph.
+    if (init) {
+      std::string out;
+      mp_out.SerializeToString(&out);
+      std::cout << out;
+    } else {
+      std::cout << buffer.str();
+    }
   } else {
-    onnx::ModelProto mp_out;
-
+    g = onnx::optimization::optimize(g, init, predict);
     onnx::optimization::encodeGraph(&mp_out, g);
-
-    if (mp_in.has_producer_name()) {
-      mp_out.set_ir_version(mp_in.ir_version());
-    }
-    if (mp_in.has_producer_name()) {
-      mp_out.set_producer_name(mp_in.producer_name());
-    }
-    if (mp_in.has_producer_version()) {
-      mp_out.set_producer_version(mp_in.producer_version());
-    }
-    if (mp_in.has_domain()) {
-      mp_out.set_domain(mp_in.domain());
-    }
-    if (mp_in.has_model_version()) {
-      mp_out.set_model_version(mp_in.model_version());
-    }
-    if (mp_in.has_doc_string()) {
-      mp_out.set_doc_string(mp_in.doc_string());
-    }
-    for (int i = 0; i < mp_in.opset_import_size(); i++) {
-      auto& oi_in = mp_in.opset_import(i);
-      auto* oi_out = mp_out.add_opset_import();
-      if (oi_in.has_domain()) {
-        oi_out->set_domain(oi_in.domain());
-      }
-      if (oi_in.has_version()) {
-        oi_out->set_version(oi_in.version());
-      }
-    }
-    for (int i = 0; i < mp_in.metadata_props_size(); i++) {
-      auto& pp_in = mp_in.metadata_props(i);
-      auto* pp_out = mp_out.add_metadata_props();
-      if (pp_in.has_key()) {
-        pp_out->set_key(pp_in.key());
-      }
-      if (pp_in.has_value()) {
-        pp_out->set_value(pp_in.value());
-      }
-    }
 
     std::string out;
     mp_out.SerializeToString(&out);

--- a/optimize-onnx/src/optimize.cpp
+++ b/optimize-onnx/src/optimize.cpp
@@ -1,0 +1,162 @@
+#include "optimize.h"
+
+#include <queue>
+
+namespace onnx { namespace optimization {
+
+const char* impure_operators[] = {
+  "RandomNormal",
+  "RandomNormalLike",
+  "RandomUniform",
+  "RandomUniformLike"
+};
+
+bool is_pure_operator(Node * n) {
+  for (auto x : impure_operators) {
+    if (n->kind() == stringToSymbol(x)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Split the graph into 'init' and 'predict' nets. This is kind of
+// like constant folding, except that rather than actually execute the
+// constant computations, we simply split them out into a separate
+// graph. Nodes that have any transitive dependency on the
+// initializers, or on impure operators, must remain in the predict
+// net. All others may be moved to the init net.
+//
+// This function destructively mutates the graph into either the init
+// or the predict net. If you want both, which you probably do,
+// arrange to call it twice.
+//
+// NOTE POTENTIAL BREAKAGE:
+//
+// The ONNX spec provides no guarantees about "staging", i.e. which
+// inputs change on every invocation vs which generally stay the same.
+// Here we make the assumption that inputs which have an initializer
+// value provided for them vary only between invocations of the init
+// net, and are constant across runs of the predict net.
+//
+std::shared_ptr<Graph> split_init_and_predict(std::shared_ptr<Graph> g, bool init, bool predict) {
+  // The first step is to identify which Values are reachable from
+  // either of
+  //   - inputs without corresponding initializers
+  //   - impure operators
+  // Any such Values belong to the predict net. Nodes belong to the
+  // predict net if they are impure or if any of their inputs do.
+
+  std::unordered_set<Value *> predict_net_values;
+
+  auto value_belongs_to_predict_net = [&](Value * v) {
+    return predict_net_values.count(v) > 0;
+  };
+  auto node_belongs_to_predict_net = [&](Node * n) {
+    return !is_pure_operator(n) ||
+        std::any_of(n->inputs().begin(),
+                    n->inputs().end(),
+                    value_belongs_to_predict_net);
+  };
+
+  {
+    std::unordered_set<std::string> initializer_names(
+      g->initializer_names().begin(),
+      g->initializer_names().end());
+
+    for (Value * v : g->inputs()) {
+      if (initializer_names.count(v->uniqueName()) == 0) {
+        predict_net_values.insert(v);
+      }
+    }
+  }
+
+  for (Node * n : g->nodes()) {
+    if (node_belongs_to_predict_net(n)) {
+      for (Value * v : n->outputs()) {
+        predict_net_values.insert(v);
+      }
+    }
+  }
+
+  // Any Value which is not itself in the predict net, but which
+  // is used by a Node which is, becomes an output of the init
+  // graph and an input of the predict net
+  std::unordered_set<Value *> new_interface;
+  for (Node * n : g->nodes()) {
+    if (node_belongs_to_predict_net(n)) {
+      for (Value * v : n->inputs()) {
+        if (!value_belongs_to_predict_net(v)) {
+          new_interface.insert(v);
+        }
+      }
+    }
+  }
+
+  if (init) {
+    // Add new outputs corresponding to the boundary between init and
+    // predict nets, ensuring that we don't duplicate outputs.
+    for (Value * v : g->outputs()) {
+      new_interface.erase(v);
+    }
+    for (Value * v : new_interface) {
+      g->registerOutput(v);
+    }
+
+    // Remove outputs that belong to the predict net.
+    for (auto i = g->outputs().size(); i--;) {
+      if (value_belongs_to_predict_net(g->outputs()[i])) {
+        g->return_node()->removeInput(0);
+      }
+    }
+
+    // Delete nodes that belong to the predict net, in reverse
+    // topological order.
+    for (auto it = g->nodes().rbegin(); it != g->nodes().rend(); it++) {
+      if (node_belongs_to_predict_net(*it)) {
+        it.destroyCurrent();
+      }
+    }
+
+    // Remove inputs that belong to the predict net.
+    for (auto i = g->inputs().size(); i--;) {
+      if (value_belongs_to_predict_net(g->inputs()[i])) {
+        g->eraseInput(i);
+      }
+    }
+  } else if (predict) {
+    // Add new inputs, ensuring that we don't introduce duplicates.
+    // Also cut the boundary between init and predict net by replacing
+    // the Values along the boundary with replaceAllUsesWith.
+    for (Value * v : g->inputs()) {
+      new_interface.erase(v);
+    }
+    for (Value * v : new_interface) {
+      Value * newv = g->addInput()->copyMetadata(v);
+      v->replaceAllUsesWith(newv);
+    }
+
+    // Delete nodes that aren't in the predict net, in reverse
+    // topological order.
+    for (auto it = g->nodes().rbegin(); it != g->nodes().rend(); it++) {
+      if (!node_belongs_to_predict_net(*it)) {
+        it.destroyCurrent();
+      }
+    }
+
+    // Remove inputs that aren't used by the predict net.
+    for (auto i = g->inputs().size(); i--;) {
+      if (g->inputs()[i]->uses().empty()) {
+        g->eraseInput(i);
+      }
+    }
+  }
+
+  return g;
+}
+
+std::shared_ptr<Graph> optimize(std::shared_ptr<Graph> g, bool init, bool predict) {
+  return split_init_and_predict(g, init, predict);
+}
+
+}}

--- a/optimize-onnx/src/optimize.h
+++ b/optimize-onnx/src/optimize.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ir.h"
+
+namespace onnx { namespace optimization {
+
+std::shared_ptr<Graph> optimize(std::shared_ptr<Graph>, bool init, bool predict);
+
+}}

--- a/tests/conversion_test.py
+++ b/tests/conversion_test.py
@@ -129,10 +129,10 @@ class TestConversion(TestCase):
 
         caffe2_init_net = caffe2_pb2.NetDef()
         caffe2_init_net.ParseFromString(init_net_output.read())
-        self.assertEqual(len(caffe2_init_net.op), 2)
+        self.assertEqual(len(caffe2_init_net.op), 1)
         self.assertEqual(set(sum([list(init_op.output)
                                   for init_op in caffe2_init_net.op], [])),
-                         {'W', 'X'})
+                         {'W'})
 
     def test_convert_end2end(self):
         predict_net_f = tempfile.NamedTemporaryFile()

--- a/tests/conversion_test.py
+++ b/tests/conversion_test.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import json
 import tempfile
 import textwrap
+import traceback
 
 from caffe2.proto import caffe2_pb2
 from caffe2.python import brew, core
@@ -31,7 +32,7 @@ class TestConversion(TestCase):
         exc_info: {}
         '''.format(result.output,
                    result.exception,
-                   result.exc_info)))
+                   traceback.format_exception(*result.exc_info))))
         return result
 
     def test_caffe2_to_onnx(self):

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -12,6 +12,7 @@ from tests.test_utils import TestCase
 
 class TestCaffe2Basic(TestCase):
     def test_dummy_name(self):
+        dummy_name([])
         names_1 = [dummy_name() for _ in range(3)]
         dummy_name([])
         names_2 = [dummy_name() for _ in range(3)]


### PR DESCRIPTION
note: this PR is going to be massive because it includes all of https://github.com/onnx/onnx-caffe2/pull/73.

Only bother looking at optimize.cpp until the other PR is merged and I can rebase on top of it.

This diff is not yet complete - in particular I haven't integrated it into backend.py yet, or done testing. However optimize.cpp is pretty much done.