### PR TITLE
default axis=1 when converting Concat from caffe2

### DIFF
--- a/onnx_caffe2/frontend.py
+++ b/onnx_caffe2/frontend.py
@@ -136,6 +136,9 @@ class Caffe2Frontend(object):
         node = cls._common_caffe2_op_to_onnx_node(op_def, shapes)
         if len(node.output) == 2:
             del node.output[1]
+        explicit_axis = any(arg.name == 'axis' for arg in op_def.arg)
+        if not explicit_axis:
+            node.attribute.extend([helper.make_attribute('axis', 1)])
         return node
 
     @classmethod

--- a/tests/optimize_onnx_test.py
+++ b/tests/optimize_onnx_test.py
@@ -45,7 +45,7 @@ class TestRoundtrip(TestCase):
     # testing just to be sure that we no-op instead of breaking on an
     # older IR version.
     def test_squeezenet_v1(self):
-        self._roundtrip('squeezenet')
+        self._roundtrip('squeezenet-ir-version-1')
 
 class TestOptimize(TestCase):
     def _optimized(self, graph):


### PR DESCRIPTION
in caffe2 this default value is provided at
https://github.com/caffe2/caffe2/blob/16dacb6b9052e6b75aa1314eabe3f77e23b7c60a/caffe2/operators/concat_split_op.h#L89