### PR TITLE
Remove aten

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "third_party/aten"]
-	path = third_party/aten
-	url = https://github.com/zdevito/ATen.git
 [submodule "third_party/onnx"]
 	path = third_party/onnx
 	url = https://www.github.com/onnx/onnx

--- a/optimize-onnx/CMakeLists.txt
+++ b/optimize-onnx/CMakeLists.txt
@@ -2,7 +2,4 @@ cmake_minimum_required(VERSION 3.0)
 
 project (opt-onnx)
 
-SET(NO_CUDA true) # affects aten
-add_subdirectory (aten)
-
 subdirs(src)

--- a/optimize-onnx/aten
+++ b/optimize-onnx/aten
@@ -1,1 +1,0 @@
-../third_party/aten

--- a/optimize-onnx/src/CMakeLists.txt
+++ b/optimize-onnx/src/CMakeLists.txt
@@ -16,8 +16,6 @@ add_executable(optimize-onnx
 
 set(CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
 
-target_include_directories(optimize-onnx PUBLIC ${CMAKE_SOURCE_DIR}/aten/src)
 target_include_directories(optimize-onnx PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_include_directories(optimize-onnx PUBLIC ${CMAKE_BINARY_DIR}/aten/src/ATen)
 target_include_directories(optimize-onnx PUBLIC ${CMAKE_BINARY_DIR}/src)
-target_link_libraries(     optimize-onnx PUBLIC ATen protobuf)
+target_link_libraries(     optimize-onnx PUBLIC protobuf)

--- a/optimize-onnx/src/array_ref.h
+++ b/optimize-onnx/src/array_ref.h
@@ -1,0 +1,181 @@
+//===--- ArrayRef.h - Array Reference Wrapper -------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// ONNX: modified from llvm::ArrayRef.
+// removed llvm-specific functionality
+// removed some implicit const -> non-const conversions that rely on
+// complicated std::enable_if meta-programming
+// removed a bunch of slice variants for simplicity...
+
+#pragma once
+#include <assert.h>
+#include <array>
+#include <vector>
+
+namespace onnx { namespace optimization {
+  /// ArrayRef - Represent a constant reference to an array (0 or more elements
+  /// consecutively in memory), i.e. a start pointer and a length.  It allows
+  /// various APIs to take consecutive elements easily and conveniently.
+  ///
+  /// This class does not own the underlying data, it is expected to be used in
+  /// situations where the data resides in some other buffer, whose lifetime
+  /// extends past that of the ArrayRef. For this reason, it is not in general
+  /// safe to store an ArrayRef.
+  ///
+  /// This is intended to be trivially copyable, so it should be passed by
+  /// value.
+  template<typename T>
+  class ArrayRef {
+  public:
+    typedef const T *iterator;
+    typedef const T *const_iterator;
+    typedef size_t size_type;
+
+    typedef std::reverse_iterator<iterator> reverse_iterator;
+
+  private:
+    /// The start of the array, in an external buffer.
+    const T *Data;
+
+    /// The number of elements.
+    size_type Length;
+
+  public:
+    /// @name Constructors
+    /// @{
+
+    /// Construct an empty ArrayRef.
+    /*implicit*/ ArrayRef() : Data(nullptr), Length(0) {}
+
+    /// Construct an ArrayRef from a single element.
+    /*implicit*/ ArrayRef(const T &OneElt)
+      : Data(&OneElt), Length(1) {}
+
+    /// Construct an ArrayRef from a pointer and length.
+    /*implicit*/ ArrayRef(const T *data, size_t length)
+      : Data(data), Length(length) {}
+
+    /// Construct an ArrayRef from a range.
+    ArrayRef(const T *begin, const T *end)
+      : Data(begin), Length(end - begin) {}
+
+    /// Construct an ArrayRef from a std::vector.
+    template<typename A>
+    /*implicit*/ ArrayRef(const std::vector<T, A> &Vec)
+      : Data(Vec.data()), Length(Vec.size()) {}
+
+    /// Construct an ArrayRef from a std::array
+    template <size_t N>
+    /*implicit*/ constexpr ArrayRef(const std::array<T, N> &Arr)
+        : Data(Arr.data()), Length(N) {}
+
+    /// Construct an ArrayRef from a C array.
+    template <size_t N>
+    /*implicit*/ constexpr ArrayRef(const T (&Arr)[N]) : Data(Arr), Length(N) {}
+
+    /// Construct an ArrayRef from a std::initializer_list.
+    /*implicit*/ ArrayRef(const std::initializer_list<T> &Vec)
+    : Data(Vec.begin() == Vec.end() ? (T*)nullptr : Vec.begin()),
+      Length(Vec.size()) {}
+
+    /// @}
+    /// @name Simple Operations
+    /// @{
+
+    iterator begin() const { return Data; }
+    iterator end() const { return Data + Length; }
+
+    reverse_iterator rbegin() const { return reverse_iterator(end()); }
+    reverse_iterator rend() const { return reverse_iterator(begin()); }
+
+    /// empty - Check if the array is empty.
+    bool empty() const { return Length == 0; }
+
+    const T *data() const { return Data; }
+
+    /// size - Get the array size.
+    size_t size() const { return Length; }
+
+    /// front - Get the first element.
+    const T &front() const {
+      assert(!empty());
+      return Data[0];
+    }
+
+    /// back - Get the last element.
+    const T &back() const {
+      assert(!empty());
+      return Data[Length-1];
+    }
+
+    /// equals - Check for element-wise equality.
+    bool equals(ArrayRef RHS) const {
+      if (Length != RHS.Length)
+        return false;
+      return std::equal(begin(), end(), RHS.begin());
+    }
+
+    /// slice(n, m) - Chop off the first N elements of the array, and keep M
+    /// elements in the array.
+    ArrayRef<T> slice(size_t N, size_t M) const {
+      assert(N+M <= size() && "Invalid specifier");
+      return ArrayRef<T>(data()+N, M);
+    }
+
+    /// slice(n) - Chop off the first N elements of the array.
+    ArrayRef<T> slice(size_t N) const { return slice(N, size() - N); }
+
+    /// @}
+    /// @name Operator Overloads
+    /// @{
+    const T &operator[](size_t Index) const {
+      assert(Index < Length && "Invalid index!");
+      return Data[Index];
+    }
+
+    /// Vector compatibility
+    const T &at(size_t Index) const {
+      assert(Index < Length && "Invalid index!");
+      return Data[Index];
+    }
+
+    /// Disallow accidental assignment from a temporary.
+    ///
+    /// The declaration here is extra complicated so that "arrayRef = {}"
+    /// continues to select the move assignment operator.
+    template <typename U>
+    typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type &
+    operator=(U &&Temporary) = delete;
+
+    /// Disallow accidental assignment from a temporary.
+    ///
+    /// The declaration here is extra complicated so that "arrayRef = {}"
+    /// continues to select the move assignment operator.
+    template <typename U>
+    typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type &
+    operator=(std::initializer_list<U>) = delete;
+
+    /// @}
+    /// @name Expensive Operations
+    /// @{
+    std::vector<T> vec() const {
+      return std::vector<T>(Data, Data+Length);
+    }
+
+    /// @}
+    /// @name Conversion operators
+    /// @{
+    operator std::vector<T>() const {
+      return std::vector<T>(Data, Data+Length);
+    }
+
+    /// @}
+  };
+
+}} // end namespace onnx::optimization

--- a/optimize-onnx/src/attributes.h
+++ b/optimize-onnx/src/attributes.h
@@ -5,8 +5,6 @@
 #include <memory>
 #include <vector>
 
-#include <ATen/ATen.h>
-
 #include "interned_strings.h"
 #include "tensor.h"
 

--- a/optimize-onnx/src/export.cpp
+++ b/optimize-onnx/src/export.cpp
@@ -1,7 +1,5 @@
 #include "export.h"
 
-#include <ATen/ATen.h>
-
 namespace onnx { namespace optimization {
 
 namespace {

--- a/optimize-onnx/src/ir.h
+++ b/optimize-onnx/src/ir.h
@@ -8,12 +8,10 @@
 #include <unordered_set>
 #include <functional>
 #include <cstdint>
-
-#include <ATen/ATen.h>
+#include <sstream>
 
 #include "utils/disallow_copy.h"
 
-#include "ATen/ArrayRef.h"
 #include "generic_if.h"
 #include "assertions.h"
 #include "interned_strings.h"
@@ -21,6 +19,7 @@
 #include "resource_guard.h"
 #include "type.h"
 #include "graph_node_list.h"
+#include "array_ref.h"
 
 namespace onnx { namespace optimization {
 
@@ -57,8 +56,6 @@ static inline bool operator==(const Use & a, const Use & b) {
 using node_list = std::vector<Node*>;
 using value_list = std::vector<Value*>;
 using use_list = std::vector<Use>;
-template<typename T>
-using ArrayRef = at::ArrayRef<T>;
 using NodeKind = Symbol;
 
 struct Value {
@@ -232,10 +229,10 @@ public:
   // way to soundly cast to std::vector<const Node*> (an insane
   // implementation of std::vector could make this representationally
   // different.)
-  at::ArrayRef<Value*> inputs() {
+  ArrayRef<Value*> inputs() {
     return inputs_;
   }
-  at::ArrayRef<const Value*> inputs() const {
+  ArrayRef<const Value*> inputs() const {
     // Vectors are not convertible in const-ness of elements, but
     // raw pointers are.
     return {inputs_.data(), inputs_.size()};
@@ -246,10 +243,10 @@ public:
   // way to soundly cast to std::vector<const Node*> (an insane
   // implementation of std::vector could make this representationally
   // different.)
-  at::ArrayRef<Value*> outputs() {
+  ArrayRef<Value*> outputs() {
     return outputs_;
   }
-  at::ArrayRef<const Value*> outputs() const {
+  ArrayRef<const Value*> outputs() const {
     // Vectors are not convertible in const-ness of elements, but
     // raw pointers are.
     return {outputs_.data(), outputs_.size()};
@@ -596,17 +593,17 @@ public:
   const std::vector<std::string>& initializer_names() {
     return initializer_names_;
   }
-  at::ArrayRef<Value*> inputs() {
+  ArrayRef<Value*> inputs() {
     return input_->outputs();
   }
-  at::ArrayRef<const Value*> inputs() const {
+  ArrayRef<const Value*> inputs() const {
     const auto & inputs = input_->outputs();
     return {inputs.data(), inputs.size()};
   }
-  at::ArrayRef<Value*> outputs() {
+  ArrayRef<Value*> outputs() {
     return output_->inputs();
   }
-  at::ArrayRef<const Value*> outputs() const {
+  ArrayRef<const Value*> outputs() const {
     return static_cast<const Node*>(output_)->inputs();
   }
   graph_node_list nodes() {

--- a/optimize-onnx/src/type.h
+++ b/optimize-onnx/src/type.h
@@ -20,13 +20,4 @@ struct Dimension {
   std::string param;
 };
 
-inline std::vector<Dimension> sizeToDimensions(at::ArrayRef<int64_t> size) {
-  std::vector<Dimension> dims;
-  dims.reserve(size.size());
-  for (auto s : size) {
-    dims.push_back(Dimension(true, s, ""));
-  }
-  return dims;
-}
-
 }} // namespace onnx::optimization


### PR DESCRIPTION
Now, the only dependencies are ArrayRef.h.

So let's remove aten dependency, and then move the optimizer onnx.

The optimizer is general enough (no caffe2 specific optimization).