### PR TITLE
Introduce Elided Arguments, and ignore input sequence_lens

### DIFF
--- a/optimize-onnx/src/export.cpp
+++ b/optimize-onnx/src/export.cpp
@@ -184,9 +184,16 @@ void encodeGraph(onnx::GraphProto * p_g, const std::shared_ptr<Graph> & g) {
       // to help symbolics do the right thing.
       continue;
     }
+    if (node->kind() == kOnnxElidedInput) {
+      continue;
+    }
     auto p_n = p_g->add_node();
     for(auto input : node->inputs()) {
-      p_n->add_input(value_name(input));
+      if (input->node()->kind() == kOnnxElidedInput) {
+        p_n->add_input("");
+      } else {
+        p_n->add_input(value_name(input));
+      }
     }
     for(auto output : node->outputs()) {
       p_n->add_output(value_name(output));

--- a/optimize-onnx/src/import.cpp
+++ b/optimize-onnx/src/import.cpp
@@ -203,6 +203,18 @@ std::unique_ptr<Graph> graphProtoToGraph(const onnx::GraphProto& gp) {
   // inputs.
   std::unordered_map<Node*, std::vector<std::string>> inputs_by_node;
 
+  {
+    // ONNX represents optional arguments in two ways
+    //  - they are simply not provided
+    //  - OR the empty string is passed as the input name
+    // This is to handle that second case, which needs a dummy node to
+    // be representable in the graph IR.
+    auto * n = g->create(kOnnxElidedInput, /* num_outputs = */ 1);
+    g->appendNode(n);
+    auto out = n->outputs()[0];
+    value_by_name_of[""] = out;
+  }
+
   for (int i = 0; i < gp.input_size(); i++) {
     auto vip = gp.input(i);
     auto v = g->addInput();

--- a/optimize-onnx/src/interned_strings.h
+++ b/optimize-onnx/src/interned_strings.h
@@ -39,6 +39,7 @@ _(SubConstant) \
 _(Scale) \
 _(Transpose) \
 _(Reshape) \
+_(OnnxElidedInput) \
 _(split) \
 _(Offset) \
 _(value) \

--- a/optimize-onnx/src/optimize.cpp
+++ b/optimize-onnx/src/optimize.cpp
@@ -173,6 +173,9 @@ void split_init_and_predict(std::shared_ptr<Graph> g, bool init, bool predict) {
       new_interface.erase(v);
     }
     for (Value * v : new_interface) {
+      if (v->node()->kind() == kOnnxElidedInput) {
+        continue;
+      }
       g->registerOutput(v);
     }
 


### PR DESCRIPTION
while ONNX has a way to represent missing arguments (pass in empty
string), that's not representable in the graph that optimize-onnx and
pytorch use. Therefore, introduce a dummy node type that stands in for
such missing arguments.

Also, ignore the passed-in sequence lens argument in favor of
rederiving it from the input size. We still much provide something to
caffe2, since it is a required argument to lstm op.